### PR TITLE
Add '-T' argument to 'mv' in install_distro.py

### DIFF
--- a/install_distro.py
+++ b/install_distro.py
@@ -129,6 +129,7 @@ def install_llvm(install_dir):
     global llvm_dir
     # install to current directory?
     cd(install_dir)
+    run(['rm', '-f', '-r', 'soft'])
     makedir('soft')
     cd('soft')
     target_url = {

--- a/install_distro.py
+++ b/install_distro.py
@@ -141,7 +141,7 @@ def install_llvm(install_dir):
     if filename.endswith('.tar.xz'):
         run(['tar', '-xf', filename])
         unzip_name = filename.replace('.tar.xz', '')
-        run(['mv', unzip_name, 'llvm-4.0'])
+        run(['mv', '-T', unzip_name, 'llvm-4.0'])
         cd_repo_root()
         llvm_dir = path.abspath(join(install_dir, 'soft', 'llvm-4.0'))
         if is_llvm_dir(llvm_dir):

--- a/install_distro.py
+++ b/install_distro.py
@@ -141,7 +141,7 @@ def install_llvm(install_dir):
     if filename.endswith('.tar.xz'):
         run(['tar', '-xf', filename])
         unzip_name = filename.replace('.tar.xz', '')
-        run(['mv', '-T', unzip_name, 'llvm-4.0'])
+        run(['mv', unzip_name, 'llvm-4.0'])
         cd_repo_root()
         llvm_dir = path.abspath(join(install_dir, 'soft', 'llvm-4.0'))
         if is_llvm_dir(llvm_dir):


### PR DESCRIPTION
The reason for using the '-T' argument in this mv command is that ~/coriander/soft/llvm-4.0 may exist.
If it does, it doesn't rename the unzipped folder to llvm-4.0 but moves it inside llvm-4.0

If llvm-4.0 is empty it will do the correct thing, if it isn't it will warn the user.