### PR TITLE
Fix llvm_version in install_distro.py

### DIFF
--- a/install_distro.py
+++ b/install_distro.py
@@ -110,7 +110,7 @@ def is_llvm_dir(p):
     clangxx_filepath = join(p, 'bin', 'clang++')
     if not path.isfile(clangxx_filepath):
         return False
-    llvm_version = run([clangxx_filepath, '--version']).split('\n')[0].split('version ')[1].split(' ')[0]
+    llvm_version = run([clangxx_filepath, '--version']).split('clang version ')[1].split(' ')[0]
     print('llvm_version', llvm_version)
     if llvm_version != REQUIRED_LLVM_VERSION:
         return False


### PR DESCRIPTION
The clang version may be on the second line if a minor error occurred when executing ~/coriander/soft/llvm-4.0/bin/clang++ --version
See issue #45
e.g:
```
/usr/lib/libtinfo.so.5: no version information available (required by ~/coriander/soft/llvm-4.0/bin/clang++)
clang version 4.0.0 (tags/RELEASE_400/final)
Target: x86_64-unknown-linux-gnu
Thread model: posix
InstalledDir: ~/coriander/soft/llvm-4.0/bin
```