### PR TITLE
[arch] Change -ltinfo to -lcurses in llvm-syslibs.sh

### DIFF
--- a/cmake/llvm-syslibs.sh
+++ b/cmake/llvm-syslibs.sh
@@ -1,5 +1,14 @@
 #!/bin/bash
 
+
 export CLANG_HOME=$1
+
+
+if (($(cat /etc/*-release | grep -ce 'arch') > 0)); then
+  SYSLIBS=$(${CLANG_HOME}/bin/llvm-config --system-libs core | tr -d '\n' | sed -e 's/ -ltinfo/ -lcurses/')
+  echo ${SYSLIBS}
+  exit 0
+fi
+
 SYSLIBS=$(${CLANG_HOME}/bin/llvm-config --system-libs core | tr -d '\n')
 echo ${SYSLIBS}


### PR DESCRIPTION
"~/coriander/soft/llvm-4.0/bin/llvm-config --system-libs core" may return "-ltinfo".
If "-ltinfo" is returned, the compilation will crash because arch doesn't have libtinfo5 installed, linking to ncurses solves the issue.