### PR TITLE
Allow cudaMalloc(ptr, 0)

### DIFF
--- a/src/cocl_memory.cpp
+++ b/src/cocl_memory.cpp
@@ -378,6 +378,10 @@ size_t  cuMemcpyDtoH(void *host_dst, CUdeviceptr gpu_src, size_t size) {
 }
 
 size_t cudaMalloc(void **_pMemory, size_t N) {
+    if(N==0){
+        (*_pMemory)=0;
+        return 0;
+    }
     Memory *memory = Memory::newDeviceAlloc(N);
     COCL_PRINT("cudaMalloc using cl, size " << N << " memory=" << (void *)memory << " fakePos=" << memory->fakePos);
     *_pMemory = (void *)memory->fakePos;
@@ -393,6 +397,9 @@ size_t cudaMalloc(float **pMemory, size_t N) {
 }
 
 size_t cudaFree(void *_memory) {
+    if(_memory==0){
+        return 0;
+    }
     Memory *memory = findMemory((char *)_memory);
     COCL_PRINT("cudafree using opencl memory=" << memory);
     delete memory;

--- a/test/endtoend/CMakeLists.txt
+++ b/test/endtoend/CMakeLists.txt
@@ -7,7 +7,7 @@ set(TESTS cuda_sample context byvaluestructwithpointer multigpu multithreading
     testevents testfloat4 test_kernelcachedok testmath testmemcpydevicetodevice test_memhostalloc
     testneg testnullpointer testpartialcopy testshfl teststream test_types
     singlebuffer test_devices test_buffers longname test_char test_structs
-    test_floatstarstar
+    test_floatstarstar test_ZeroCudaMalloc
 )
 
 # include_directories(include/cocl/proxy_includes)

--- a/test/endtoend/test_ZeroCudaMalloc.cu
+++ b/test/endtoend/test_ZeroCudaMalloc.cu
@@ -1,0 +1,21 @@
+
+#include <iostream>
+#include <memory>
+#include <cassert>
+
+using namespace std;
+
+#include <cuda.h>
+
+int main(int argc, char *argv[]) {
+    int num=25;
+    CUdeviceptr loc[num];
+    for(int i=0; i<num; i++){
+	std::cout << "i: " << i << std::endl;
+        cuMemAlloc(&loc[i], i);
+    }
+    for(int i=0; i<num; i++){
+        cuMemFree(loc[i]);
+    }
+    return 0;
+}


### PR DESCRIPTION
This makes the behaviour more like malloc.
This is beneficial because a program may excpect a subroutine to request for a certain amount of memory, and allocate the requested amount.
They don't check whether this amount is == 0 and thus may cause crashes if the requested amount is equal to 0.
The OpenCL spec states that clCreateBuffer calls with size 0 must error, but malloc(0) must not error.