### PR TITLE
Fix floor(), properly implement ceil()

### DIFF
--- a/include/cocl/fake_funcs.h
+++ b/include/cocl/fake_funcs.h
@@ -122,8 +122,15 @@ __device__ float fabsf(float in1);
 __device__ float fabs(float in1);
 __device__ float sqrtf(float in1);
 __device__ float rsqrtf(float in1);
-__device__ float ceilf(float in1);
+
 __device__ float floorf(float in1);
+__device__ double floor(double in1);
+__device__ float floor(float in1);
+
+__device__ float ceilf(float in1);
+__device__ double ceil(double in1);
+__device__ float ceil(float in1);
+
 __device__ void sincosf(float angle, float *sinres, float *cosres);
 
 __device__ float pow(float in1, float in2);

--- a/src/function_names_map.cpp
+++ b/src/function_names_map.cpp
@@ -56,8 +56,17 @@ void FunctionNamesMap::populateKnownValues() {
     knownFunctionsMap["cosf"] = "cos";
     knownFunctionsMap["sinf"] = "sin";
     knownFunctionsMap["tanf"] = "tan";
-    knownFunctionsMap["ceilf"] = "ceil";
+    
+    knownFunctionsMap["floor"] = "floor";
     knownFunctionsMap["floorf"] = "floor";
+    knownFunctionsMap["_Z5floorf"] = "floor";
+    knownFunctionsMap["_Z5floord"] = "floor";
+    
+    knownFunctionsMap["ceil"] = "ceil";
+    knownFunctionsMap["ceilf"] = "ceil";
+    knownFunctionsMap["_Z4ceilf"] = "ceil";
+    knownFunctionsMap["_Z4ceild"] = "ceil";
+    
     knownFunctionsMap["logf"] = "log";
     knownFunctionsMap["sqrtf"] = "sqrt";
 


### PR DESCRIPTION
Hey Hugh, here's another one :) This fixes issue #61 and also properly implements ceil(). We should probably systematically check all standard library functions and make sure they work both for float and double, and with `std::` prefix. I suspect there are at the moment more problems of this kind lurking.