### PR TITLE
MinGW-w64 build implemented

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,7 +99,7 @@ set(COCL_SRCS src/type_dumper.cpp src/GlobalNames.cpp src/LocalNames.cpp src/new
     src/cocl_funcs.cpp
 )
 
-if(WIN32)
+if(MSVC)
   set(CMAKE_CXX_FLAGS "/EHsc")
 else()
   SET(PLATFORM_OPTIONS "")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -210,14 +210,14 @@ target_link_libraries(ir-to-opencl cocl ${LLVM_SYSLIBS})
 add_executable(patch_hostside
     src/patch_hostside.cpp src/struct_clone.cpp src/mutations.cpp src/readIR.cpp
     third_party/argparsecpp/argparsecpp.cpp src/type_dumper.cpp src/GlobalNames.cpp
-    src/EasyCL/util/easycl_stringhelper.cpp src/cocl_logging.cpp
+    src/cocl_logging.cpp
 )
 target_include_directories(patch_hostside PRIVATE ${CLANG_HOME}/include)
 target_include_directories(patch_hostside PRIVATE include)
 target_include_directories(patch_hostside PRIVATE third_party)
 target_include_directories(patch_hostside PRIVATE src/EasyCL)
 target_compile_options(patch_hostside PRIVATE ${LLVM_CXXFLAGS} ${LLVM_DEFINES})
-target_link_libraries(patch_hostside "${LLVM_LIBPATHS}"  ${LLVM_SYSLIBS})
+target_link_libraries(patch_hostside "${LLVM_LIBPATHS}"  ${LLVM_SYSLIBS} easycl)
 
 # ==================================================================================================
 # tests

--- a/include/cocl/cocl_streams.h
+++ b/include/cocl/cocl_streams.h
@@ -38,7 +38,7 @@ namespace cocl {
         void *userdata;
         char *_queue;
     };
-    void coclCallback(cl_event event, cl_int status, void *userdata);
+    void CL_CALLBACK coclCallback(cl_event event, cl_int status, void *userdata);
 
     // a coclstream:
     // - is associated with one virtual cuda stream, from the point of view of the client

--- a/include/cocl/shims.h
+++ b/include/cocl/shims.h
@@ -19,10 +19,11 @@
 #include <set>
 #include <map>
 #include <string>
+#include "cocl_export.h"
 
 namespace cocl {
 
-class Shims {
+class cocl_EXPORT Shims {
 public:
     Shims();
     virtual ~Shims() {}


### PR DESCRIPTION
1. build llvm libs since the prebuilt llvm doesn't cointain them. I recommend to use ninja since if you encounter any errors in process you won't have to start the build from scratch. https://github.com/llvm-mirror/llvm/pull/64 also would be helpful for the first time.
2. check if llvm-config is built too. It must be built, but if it is not (I haven't managed to build it even though the it is present in `build.ninja`), add `-l:LLVMBinaryFormat.dll -l:LLVMCore.dll -l:LLVMSupport.dll -l:LLVMIRReader.dll -l:LLVMTransformUtils.dll  -L .` to `CMAKE_*_LINKER_FLAGS` and copy the mentioned libs to your build directory.
3. You can build coriander for Windows. Though I have not tested if it works.

4. you must pass `--target=i686-pc-windows-gnu` if you use MinGW on 32-bit windows and `-I<paths to include dirs for MinGW>`

