### PR TITLE
Added platform selection as an environment variable

### DIFF
--- a/bin/cocl
+++ b/bin/cocl
@@ -459,6 +459,7 @@ if [ ! "$COMPILE" ]; then {
             ${OPT_G} \
             -o ${OUTPUTBASEPATH}${FINALPOSTFIX} ${OUTPUTBASEPATH}${OUTPUTPOSTFIX} \
             -L${COCL_LIB} -lcocl -lclblast -leasycl -lclew -lpthread \
+            ${EXTRA_LINKER_ARGS} \
             ${LLVM_LINK_FLAGS}
     )
 } fi

--- a/src/cocl_device.cpp
+++ b/src/cocl_device.cpp
@@ -79,7 +79,6 @@ namespace cocl {
         // this->platform_id = _platform_id;
         // this->device_id = _device_id;
     }
-
     int numGpus = 0;
     std::vector<std::unique_ptr<cocl::CoclDevice> > deviceByOrdinal;
     bool devicesInitialized = false;


### PR DESCRIPTION
Added platform selection via environment variable export.
We can now use CL_PLATFORMOFFSET=x -- akin to the existing CL_GPUOFFSET=x to select both device and platform. This is needed since the Nvidia GPU platform isn't always platform 0.